### PR TITLE
N bissle nettere workflow config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,14 @@
 name: Build ZMK firmware
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+    paths:
+      - 'config/**'
+      - 'zephyr/**'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
jetzt kann man tags pushen {z.b. fuer den letzten kompilierenden stand} ohne dass immer ein neuer build losrennt. vielleicht ist das interessant fuer dich.